### PR TITLE
Fix drag and dropping images on Linux

### DIFF
--- a/Source/EditorTab.cpp
+++ b/Source/EditorTab.cpp
@@ -287,12 +287,22 @@ public:
 
     void dragEnterEvent(QDragEnterEvent* pEvent) override
     {
-        QUrl path = pEvent->mimeData()->text();
-        QFileInfo info(path.toLocalFile());
-        if (info.completeSuffix() == "png" ||
-            info.completeSuffix() == "jpg")
+        if (pEvent->mimeData()->hasImage())
         {
             pEvent->acceptProposedAction();
+        }
+        else if (pEvent->mimeData()->hasUrls())
+        {
+            QUrl      fileUrl = pEvent->mimeData()->urls().first();
+            QMimeType mimeType = QMimeDatabase().mimeTypeForUrl(fileUrl);
+
+            qDebug() << fileUrl;
+            qDebug() << mimeType.name();
+
+            if (mimeType.name().startsWith("image"))
+            {
+                pEvent->acceptProposedAction();
+            }
         }
     }
 
@@ -303,7 +313,7 @@ public:
 
     void dropEvent(QDropEvent* pEvent) override
     {
-        QUrl imgPath = pEvent->mimeData()->text();
+        QUrl imgPath = pEvent->mimeData()->urls().first();
         const QPoint scenePos = mapToScene(pEvent->pos()).toPoint();
         CameraManager cameraManager(this, mEditorTab, &scenePos);
         cameraManager.CreateCamera(true, QPixmap(imgPath.toLocalFile()));

--- a/Source/EditorTab.cpp
+++ b/Source/EditorTab.cpp
@@ -298,39 +298,25 @@ public:
     void dropEvent(QDropEvent* pEvent) override
     {
         // Attempt to load the dropped image
-        //
-        QUrl    imgUrl = pEvent->mimeData()->urls().first();
+        QUrl imgUrl = pEvent->mimeData()->urls().first();
         QPixmap img;
 
         if (!imgUrl.isLocalFile())
         {
-            QMessageBox::critical(
-                this,
-                "Error",
-                "Reading from remote file systems is unsupported."
-            );
-
+            QMessageBox::critical(this, "Error", "Reading from remote file systems is unsupported.");
             return;
         }
 
         if (!img.load(imgUrl.toLocalFile()))
         {
-            QMessageBox::critical(
-                this,
-                "Error",
-                "The file dropped could not be understood as an image."
-            );
-
+            QMessageBox::critical(this, "Error", "The file dropped could not be understood as an image.");
             return;
         }
 
         // Image is valid, continue
-        //
         const QPoint scenePos = mapToScene(pEvent->pos()).toPoint();
-
         CameraManager cameraManager(this, mEditorTab, &scenePos);
         cameraManager.CreateCamera(true, img);
-
         pEvent->acceptProposedAction();
     }
 


### PR DESCRIPTION
Basically let QPixmap try to load whatever has been dropped in - should also expand image file support to whatever QPixmap supports rather than just .jpg and .png

Tested in pcmanfm and Thunar